### PR TITLE
exclude AWS SDK apache-client

### DIFF
--- a/spring-funk-aws/build.gradle.kts
+++ b/spring-funk-aws/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
 
 dependencies {
     api(project(":spring-funk-base"))
-    api(aws.s3)
+    api(aws.s3) {
+        exclude(group = "software.amazon.awssdk", module = "apache-client")
+    }
     implementation(aws.netty)
     implementation(libs.slf4j)
     implementation(libs.oshai)


### PR DESCRIPTION
# Motivation

`spring-funk-aws` explicitly configures the Netty HTTP client for the AWS SDK.

The Apache Client is not required and should be excluded.
