### PR TITLE
add a Logging DSL

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,25 @@
+---
+layout: default
+title: Logging
+nav_order: 8
+has_children: false
+parent: Built-in DSLs
+---
+
+# Logging DSL
+
+This DSL allows you to configure logging levels. Setting levels with `logging.level` configuration properties will override the DSL setting.
+
+## Usage
+
+```kotlin
+class TestKotlinApplication : SpringFunkApplication {
+    override fun dsl(): SpringDslContainer.() -> Unit = {
+        logging {
+            root(LogLevel.INFO)
+            level<MyClass>(LogLevel.OFF)
+            level("com.example.package", LogLevel.DEBUG)
+        }
+    }
+}
+```

--- a/spring-funk-base/src/main/kotlin/com/github/wakingrufus/funk/beans/BeansDsl.kt
+++ b/spring-funk-base/src/main/kotlin/com/github/wakingrufus/funk/beans/BeansDsl.kt
@@ -5,6 +5,7 @@ import com.github.wakingrufus.funk.core.SpringDslContainer
 import com.github.wakingrufus.funk.core.SpringDslMarker
 import org.springframework.context.support.BeanDefinitionDsl
 
+@SpringDslMarker
 class BeansDsl : SpringDsl {
     internal var beansDsl: BeanDefinitionDsl? = null
 

--- a/spring-funk-base/src/main/kotlin/com/github/wakingrufus/funk/logging/LoggingDsl.kt
+++ b/spring-funk-base/src/main/kotlin/com/github/wakingrufus/funk/logging/LoggingDsl.kt
@@ -1,0 +1,31 @@
+package com.github.wakingrufus.funk.logging
+
+import com.github.wakingrufus.funk.core.SpringDsl
+import com.github.wakingrufus.funk.core.SpringDslContainer
+import com.github.wakingrufus.funk.core.SpringDslMarker
+import org.springframework.boot.logging.LogLevel
+
+@SpringDslMarker
+class LoggingDsl : SpringDsl {
+    internal val levels: MutableMap<String, LogLevel> = mutableMapOf()
+
+    @SpringDslMarker
+    fun root(level: LogLevel) {
+        levels["ROOT"] = level
+    }
+
+    @SpringDslMarker
+    fun level(packageName: String, level: LogLevel) {
+        levels[packageName] = level
+    }
+
+    @SpringDslMarker
+    inline fun <reified T> level(level: LogLevel) {
+        T::class.qualifiedName?.also { level(it, level) }
+    }
+}
+
+@SpringDslMarker
+fun SpringDslContainer.logging(config: LoggingDsl.() -> Unit) {
+    register(LoggingDsl().apply(config))
+}

--- a/spring-funk-base/src/main/kotlin/com/github/wakingrufus/funk/logging/LoggingDslInitializer.kt
+++ b/spring-funk-base/src/main/kotlin/com/github/wakingrufus/funk/logging/LoggingDslInitializer.kt
@@ -1,0 +1,15 @@
+package com.github.wakingrufus.funk.logging
+
+import com.github.wakingrufus.funk.base.getDsl
+import org.springframework.boot.logging.LoggingSystem
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.support.GenericApplicationContext
+
+class LoggingDslInitializer : ApplicationContextInitializer<GenericApplicationContext> {
+    override fun initialize(applicationContext: GenericApplicationContext) {
+        val loggingSystem: LoggingSystem = LoggingSystem.get(LoggingDslInitializer::class.java.classLoader)
+        applicationContext.getDsl<LoggingDsl>()?.levels?.forEach { (name, level) ->
+            loggingSystem.setLogLevel(name, level)
+        }
+    }
+}

--- a/spring-funk-base/src/main/resources/META-INF/spring.factories
+++ b/spring-funk-base/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.context.ApplicationContextInitializer=\
-com.github.wakingrufus.funk.beans.BeanDslInitializer
+com.github.wakingrufus.funk.beans.BeanDslInitializer,\
+com.github.wakingrufus.funk.logging.LoggingDslInitializer

--- a/spring-funk-base/src/test/kotlin/com/github/wakingrufus/funk/logging/LoggingDslTest.kt
+++ b/spring-funk-base/src/test/kotlin/com/github/wakingrufus/funk/logging/LoggingDslTest.kt
@@ -1,0 +1,87 @@
+package com.github.wakingrufus.funk.logging
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import com.github.wakingrufus.funk.test.testDslApplication
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.boot.logging.LogLevel
+import org.springframework.boot.logging.LoggingSystem
+
+class LoggingDslTest {
+    private val log = KotlinLogging.logger {}
+    private lateinit var logAppender: ListAppender<ILoggingEvent>
+
+    @BeforeEach
+    fun setup() {
+        logAppender = ListAppender<ILoggingEvent>()
+        logAppender.start()
+    }
+
+    @AfterEach
+    fun clean() {
+        logAppender.stop()
+    }
+
+    @Test
+    fun test() {
+        val logger = LoggerFactory.getLogger(LoggingDslTest::class.java) as Logger
+        logger.addAppender(logAppender)
+
+        testDslApplication(LoggingDslInitializer()) {
+            application {
+
+            }
+            environment {
+            }
+            test {
+                log.info { "test" }
+                assertThat(logAppender.list).hasSize(1)
+                assertThat(logAppender.list[0].message).isEqualTo("test")
+            }
+        }
+    }
+
+    @Test
+    fun `test root level`() {
+        val logger = LoggerFactory.getLogger(LoggingDslTest::class.java) as Logger
+        logger.addAppender(logAppender)
+
+        testDslApplication(LoggingDslInitializer()) {
+            application {
+                logging {
+                    root(LogLevel.DEBUG)
+                }
+            }
+            environment {
+            }
+            test {
+                val loggingSystem = LoggingSystem.get(LoggingDslTest::class.java.classLoader)
+                assertThat(loggingSystem.getLoggerConfiguration("ROOT").effectiveLevel)
+                    .isEqualTo(LogLevel.DEBUG)
+            }
+        }
+    }
+
+    @Test
+    fun `test logger off`() {
+        testDslApplication(LoggingDslInitializer()) {
+            application {
+                logging {
+                    level<LoggingDslTest>(LogLevel.OFF)
+                }
+            }
+            environment {
+            }
+            test {
+                log.info { "test" }
+                assertThat(logAppender.list).hasSize(0)
+            }
+        }
+    }
+}

--- a/test-application/build.gradle.kts
+++ b/test-application/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies{
     implementation(project(":spring-funk-webmvc"))
     implementation(spring.boot.jetty)
     implementation("ch.qos.logback:logback-classic:1.5.6")
+    implementation(libs.oshai)
 
     testImplementation(spring.boot.test)
 }

--- a/test-application/src/main/kotlin/com/github/wakingrufus/funk/example/ExampleApplication.kt
+++ b/test-application/src/main/kotlin/com/github/wakingrufus/funk/example/ExampleApplication.kt
@@ -2,18 +2,27 @@ package com.github.wakingrufus.funk.example
 
 import com.github.wakingrufus.funk.base.SpringFunkApplication
 import com.github.wakingrufus.funk.core.SpringDslContainer
+import com.github.wakingrufus.funk.logging.logging
 import com.github.wakingrufus.funk.webmvc.webmvc
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.boot.SpringApplication
+import org.springframework.boot.logging.LogLevel
 import org.springframework.web.servlet.function.ServerResponse
 
 class ExampleApplication : SpringFunkApplication {
+    private val log = KotlinLogging.logger {}
     override fun dsl(): SpringDslContainer.() -> Unit = {
+        logging {
+            root(LogLevel.INFO)
+            level("com.github.wakingrufus", LogLevel.INFO)
+        }
         webmvc {
             enableWebMvc {
                 jetty()
             }
             router {
                 GET("/dsl") {
+                    log.debug { "handling hello world request" }
                     ServerResponse.ok().body("Hello World")
                 }
             }

--- a/test-application/src/test/kotlin/com/github/wakingrufus/funk/example/ExampleApplicationTest.kt
+++ b/test-application/src/test/kotlin/com/github/wakingrufus/funk/example/ExampleApplicationTest.kt
@@ -8,7 +8,11 @@ import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.boot.test.web.client.getForEntity
 import java.net.URI
 
-@SpringBootTest(classes = [ExampleApplication::class], webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+    classes = [ExampleApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = ["logging.level.com.github.wakingrufus.funk=DEBUG"]
+)
 class ExampleApplicationTest {
 
     @Autowired


### PR DESCRIPTION
This DSL allows you to configure logging levels. Setting levels with `logging.level` configuration properties will override the DSL setting.