### PR TITLE
Update instances of spring-dsl to spring-funk in the documentation

### DIFF
--- a/docs/built_in_dsls.md
+++ b/docs/built_in_dsls.md
@@ -6,4 +6,4 @@ has_children: true
 ---
 # Built-in DSLs
 
-There are a number of DSLs provided by the spring-dsl project. Most of these expose existing Spring DSLs, or replace core Spring Boot AutoConfigurations.
+There are a number of DSLs provided by the spring-funk project. Most of these expose existing Spring DSLs, or replace core Spring Boot AutoConfigurations.

--- a/docs/custom_dsl_configuration.md
+++ b/docs/custom_dsl_configuration.md
@@ -18,13 +18,13 @@ class ExampleDsl : SpringDsl {
 }
 ```
 
-Then, in your initializer, register the ConfigurationProperties using the helper provided by the spring-dsl-runtimeconfig package
+Then, in your initializer, register the ConfigurationProperties using the helper provided by the spring-funk-runtimeconfig package
 ### Example
 ```kotlin
 val defaultInstance = applicationContext.getDsl<ExampleDsl>()?.defaults
 applicationContext.registerRuntimeConfig<ExampleConfig>(defaultInstance = defaultInstance)
 ```
-Then use the config in your bean using another helper from spring-dsl-runtimeconfig
+Then use the config in your bean using another helper from spring-funk-runtimeconfig
 
 ### Example
 ```kotlin

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -10,7 +10,7 @@ Starting from a standard Spring Boot Application, add the following dependency t
 
 ```kotlin
 dependencies {
-    implementation("com.github.wakingrufus.springdsl:spring-dsl-base")
+    implementation("io.github.wakingrufus:spring-funk-base:0.3.0")
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ has_children: false
 
 Spring Fun(ctional)K(otlin) is a framework for declarative DSL configuration for Spring Boot.
 
-View source and report issues on [GitHub](https://github.com/wakingrufus/spring-dsl).
+View source and report issues on [GitHub](https://github.com/wakingrufus/spring-funk).
 
 For a brief conceptual introduction, see the [Introduction](introduction.md).
 

--- a/docs/testing_custom_dsls.md
+++ b/docs/testing_custom_dsls.md
@@ -6,7 +6,7 @@ nav_order: 4
 ---
 # Testing Custom DSLs
 
-Custom DSLs can be used in Test Spring Boot applications and tested via `@SpringBootTest`, but spring-dsl-test provides a test fixture that facilitates faster tests which can share a test class. To use it, use the `testDslApplication` function. This function takes a list of initializers to run. Pass your initializer you want to test in here.
+Custom DSLs can be used in Test Spring Boot applications and tested via `@SpringBootTest`, but spring-funk-test provides a test fixture that facilitates faster tests which can share a test class. To use it, use the `testDslApplication` function. This function takes a list of initializers to run. Pass your initializer you want to test in here.
 
 ### Example
 ```kotlin


### PR DESCRIPTION
While reviewing the documentation for this project, I noticed that there are some existing instances of `spring-dsl` when talking about the available dependencies. The project has since been renamed to _Spring Funk_, so I have updated the instances of `spring-dsl` to `spring-funk`.