### PR TITLE
remove restriction on htmx response types

### DIFF
--- a/spring-funk-htmx/src/main/kotlin/com/github/wakingrufus/funk/htmx/HtmxPage.kt
+++ b/spring-funk-htmx/src/main/kotlin/com/github/wakingrufus/funk/htmx/HtmxPage.kt
@@ -39,7 +39,7 @@ class HtmxPage(val path: String) {
      * use when declaring a GET route that takes no parameters
      */
     @SpringDslMarker
-    inline fun <reified CONTROLLER : Any, RESP : Record> get(
+    inline fun <reified CONTROLLER : Any, RESP : Any> get(
         path: String,
         noinline binding: CONTROLLER.() -> RESP,
         noinline renderer: (RESP) -> TagConsumer<Document>.() -> Document
@@ -54,7 +54,7 @@ class HtmxPage(val path: String) {
     }
 
     @SpringDslMarker
-    inline fun <reified CONTROLLER : Any, reified REQ : Record, RESP : Record> route(
+    inline fun <reified CONTROLLER : Any, reified REQ : Record, RESP : Any> route(
         verb: HttpVerb,
         path: String,
         noinline binding: CONTROLLER.(REQ) -> RESP,

--- a/spring-funk-htmx/src/main/kotlin/com/github/wakingrufus/funk/htmx/route/HxRoute.kt
+++ b/spring-funk-htmx/src/main/kotlin/com/github/wakingrufus/funk/htmx/route/HxRoute.kt
@@ -11,7 +11,7 @@ interface HxRoute {
     fun registerRoutes(beanFactory: BeanFactory, dsl: RouterFunctionDsl)
 }
 
-fun <CONTROLLER : Any, REQ : Record, RESP : Record> withParam(
+fun <CONTROLLER : Any, REQ : Record, RESP : Any> withParam(
     routerFunction: RouterFunctionDsl.(String, (ServerRequest) -> ServerResponse) -> Unit,
     path: String,
     requestClass: Class<REQ>,
@@ -22,7 +22,7 @@ fun <CONTROLLER : Any, REQ : Record, RESP : Record> withParam(
     return ParamRoute(routerFunction, path, requestClass, controllerClass, binding, renderer)
 }
 
-fun <CONTROLLER : Any, RESP : Record> noParam(
+fun <CONTROLLER : Any, RESP : Any> noParam(
     routerFunction: RouterFunctionDsl.(String, (ServerRequest) -> ServerResponse) -> Unit,
     path: String,
     controllerClass: Class<CONTROLLER>,

--- a/spring-funk-htmx/src/main/kotlin/com/github/wakingrufus/funk/htmx/route/NoParamRoute.kt
+++ b/spring-funk-htmx/src/main/kotlin/com/github/wakingrufus/funk/htmx/route/NoParamRoute.kt
@@ -11,7 +11,7 @@ import org.springframework.web.servlet.function.ServerResponse
 import org.springframework.web.servlet.function.contentTypeOrNull
 import org.w3c.dom.Document
 
-class NoParamRoute<CONTROLLER : Any, RESP : Record>(
+class NoParamRoute<CONTROLLER : Any, RESP : Any>(
     val routerFunction: RouterFunctionDsl.(String, (ServerRequest) -> ServerResponse) -> Unit,
     val path: String,
     private val controllerClass: Class<CONTROLLER>,

--- a/spring-funk-htmx/src/main/kotlin/com/github/wakingrufus/funk/htmx/route/ParamRoute.kt
+++ b/spring-funk-htmx/src/main/kotlin/com/github/wakingrufus/funk/htmx/route/ParamRoute.kt
@@ -14,7 +14,7 @@ import org.springframework.web.servlet.function.ServerResponse
 import org.springframework.web.servlet.function.contentTypeOrNull
 import org.w3c.dom.Document
 
-class ParamRoute<CONTROLLER : Any, REQ : Record, RESP : Record>(
+class ParamRoute<CONTROLLER : Any, REQ : Record, RESP : Any>(
     val routerFunction: RouterFunctionDsl.(String, (ServerRequest) -> ServerResponse) -> Unit,
     val path: String,
     private val requestClass: Class<REQ>,


### PR DESCRIPTION
forcing response types to be records would not allow monads (sealed classes) to be used